### PR TITLE
Fixed error from "desync"?

### DIFF
--- a/entities/collectables/arrow.gd
+++ b/entities/collectables/arrow.gd
@@ -2,4 +2,5 @@ extends Collectable
 
 func _on_collect(body):
 	global.ammo.arrow += 1
-	body.hud.update_weapons()
+	global.player.hud.update_weapons()
+	

--- a/entities/collectables/bomb.gd
+++ b/entities/collectables/bomb.gd
@@ -2,4 +2,5 @@ extends Collectable
 
 func _on_collect(body):
 	global.ammo.bomb += 1
-	body.hud.update_weapons()
+	global.player.hud.update_weapons()
+	

--- a/entities/collectables/heart.gd
+++ b/entities/collectables/heart.gd
@@ -2,4 +2,4 @@ extends Collectable
 
 func _on_collect(body):
 	body.health += 1
-	body.hud.update_hearts()
+	global.player.hud.update_hearts()

--- a/entities/collectables/tetran.gd
+++ b/entities/collectables/tetran.gd
@@ -17,4 +17,4 @@ func _ready():
 
 func _on_collect(body):
 	global.ammo.tetrans += value
-	body.hud.update_tetrans()
+	global.player.hud.update_tetrans()


### PR DESCRIPTION
I believe this fixes the error (#239) from displaying, by using global.player i saw the chests using instead of body. There should be some more testing before this is committed, but I got no errors from collectibles after these changes.

No screenshot as like this is getting rid of an error not showing something happening.

#### Summary
Changed "body" to "global.player" in the four currently added collectibles. Any future I assume need to use it as well.

#### Testing
Create multiplayer game. Collect things. See no error hopefully lol.
