### PR TITLE
Fade out music when changing maps

### DIFF
--- a/engine/global.gd
+++ b/engine/global.gd
@@ -135,7 +135,8 @@ func change_map(map, entrance):
 	if changing_map:
 		return
 	changing_map = true
-	
+
+	sfx.fadeout_music()
 	screenfx.play("fadewhite")
 	yield(screenfx, "animation_finished")
 	

--- a/sound/sound.gd
+++ b/sound/sound.gd
@@ -8,15 +8,22 @@ const DEFAULT_SFX_VOLUME = -15
 const DEFAULT_MUSIC_VOLUME = -20
 const QUIET_MUSIC_VOLUME = -27.5
 
+var music_fadingout = false
 var music_volume = DEFAULT_MUSIC_VOLUME
 
 func _ready():
 	add_child(music)
 
 func _process(delta):
+	if music_fadingout:
+		music_volume -= delta * 30
 	music.volume_db = lerp(music.volume_db, music_volume, 0.1)
 
+func fadeout_music():
+	music_fadingout = true
+
 func set_music(song, musicfx = ""):
+	music_fadingout = false
 	if gameover == false:
 		music_volume = DEFAULT_MUSIC_VOLUME
 		if song != current_song:


### PR DESCRIPTION
#### Summary
Fades out music when travelling between maps. Makes the shrine/overworld transition feel less jarring.
Note that I'm not 100% sure I've done this correctly.

#### Testing
Walk through a map transition (I tested with shrine-overworld), and listen to the volume of the music.
(Note that zone transitions don't have this apply to them - I'm relying on the fadeout time to give time for the fadeout.)