### PR TITLE
Network Fixed

### DIFF
--- a/engine/network.gd
+++ b/engine/network.gd
@@ -187,6 +187,8 @@ func set_state(path, properties):
 func add_to_state(state, value):
 	if !states.get(state).has(value):
 		states.get(state).append(value)
+		global.set(state, states.get(state))
+		rpc("_receive_state_array", state, states.get(state))
 		set_state(state, states.get(state))
 
 remote func _receive_state_change(nodepath, properties):


### PR DESCRIPTION
*This is the issue that got resolved - Closes #279
![](https://cdn.discordapp.com/attachments/813810085964152895/863851108589109299/unknown.png)

### Summary
Chest Items were not properly networked. They are now working

### Testing
Place any chest in Shrine, test in Multiplayer

[**Has this been tested in multiplayer?**](https://github.com/loudsmilestudios/TetraForce/wiki/How-to-test-multiplayer) *yes*
