### PR TITLE
*FIX* Sync Multiplayer Objects

### DIFF
--- a/engine/game.gd
+++ b/engine/game.gd
@@ -37,6 +37,8 @@ func _process(delta): # can be on screen change instead of process
 	if !network.is_map_host():
 		return
 	
+	update_spiritpearls()
+	
 	var active_zones = []
 	var active_enemies = []
 	
@@ -128,6 +130,14 @@ func create_collectable(path, pos):
 		call_deferred("add_child", new_collectable)
 		new_collectable.position = pos
 		
+func update_spiritpearls():
+	if global.pearl.size() >= 4:
+		global.max_health += 1
+		global.player.hud.on_full_slate()
+		network.states["pearl"].clear()
+		global.pearl.clear()
+		network.peer_call(self, "update_spiritpearls")
+	global.emit_signal("debug_update")
 
 
 

--- a/engine/global.gd
+++ b/engine/global.gd
@@ -151,3 +151,10 @@ func change_map(map, entrance):
 	root.add_child(new_map)
 	
 	emit_signal("debug_update")
+
+func count_pearl():
+	spiritpearl += 1
+	if spiritpearl >= 4:
+		max_health += 1
+		player.hud.on_full_slate()
+		spiritpearl = 0

--- a/engine/global.gd
+++ b/engine/global.gd
@@ -4,7 +4,7 @@ var player
 var equips = {"B": "Sword", "X": "", "Y": ""}
 var weapons = ["Sword"]
 var items = []
-var pearl =["Spiritpearl"]
+var pearl = []
 var health = 5
 var max_health = 5
 var spiritpearl = 0
@@ -151,10 +151,3 @@ func change_map(map, entrance):
 	root.add_child(new_map)
 	
 	emit_signal("debug_update")
-
-func count_pearl():
-	spiritpearl += 1
-	if spiritpearl >= 4:
-		max_health += 1
-		player.hud.on_full_slate()
-		spiritpearl = 0

--- a/engine/main.gd
+++ b/engine/main.gd
@@ -7,7 +7,7 @@ var server_api = preload("res://engine/server_api.gd").new()
 
 onready var address_line = $multiplayer/Manual/address
 onready var lobby_line = $multiplayer/Automatic/lobby
-onready var endpoint_button = $options/scroll/vbox/endpoint
+#onready var endpoint_button = $options/scroll/vbox/endpoint JosephB Needs to confirm deletion
 onready var singleplayer_focus = $top/VBoxContainer/singleplayer
 onready var loading_screen = $loading_screen_layer/loading_screen
 

--- a/engine/network.gd
+++ b/engine/network.gd
@@ -22,11 +22,14 @@ signal received_player_list
 
 var player_data = {}
 
+var state
+
 # save stuff
 # states[nodepath] = properties
 var states = {
 	weapons = [],
 	items = [],
+	pearl = [],
 }
 
 func _ready():
@@ -34,6 +37,8 @@ func _ready():
 	#get_tree().connect("network_peer_connected", self, "_player_connected")
 	get_tree().connect("network_peer_disconnected", self, "_player_disconnected")
 	states.weapons = global.weapons
+	states.items = global.items
+	states.pearl = global.pearl
 
 func clean_session_data():
 	current_players = []
@@ -65,6 +70,12 @@ func initialize():
 	yield(get_tree().create_timer(0.1), "timeout")
 	
 	global.emit_signal("debug_update")
+	
+remote func _sync_item_list(state, value):
+	states[state] = state
+	match state:
+			"weapons", "items", "pearl":
+				pass
 
 remote func _receive_my_player_data(data):
 	var player_name = data.name
@@ -176,23 +187,27 @@ func is_map_host():
 func get_map_host():
 	return map_hosts.get(current_map.name)
 
-func set_state(path, properties):
-	#var nodepath = object.get_path()
+remote func set_state(path, properties):
 	if pid == 1:
 		states[path] = properties
+		rpc("_receive_state_array", path, properties)
 		global.emit_signal("debug_update")
 	else:
-		rpc_id(1, "_receive_state_change", path, properties)
+		rpc_id(1, "_receive_state_array", path, properties)
 
-func add_to_state(state, value):
-	if !states.get(state).has(value):
+remote func add_to_state(state, value):
+	if !states.get(state).has(value) || states.get(state).has("Spiritpearl"):
 		states.get(state).append(value)
 		global.set(state, states.get(state))
-		rpc("_receive_state_array", state, states.get(state))
+		rpc("_receive_state_change", state, states.get(state))
 		set_state(state, states.get(state))
 
 remote func _receive_state_change(nodepath, properties):
 	states[nodepath] = properties
+	global.emit_signal("debug_update")
+	
+remote func _receive_state_array(state, value):
+	global.set(state, value)
 	global.emit_signal("debug_update")
 
 func request_persistent_state(object):
@@ -213,10 +228,6 @@ remote func _receive_state(nodepath, properties):
 func update_state(nodepath, properties):
 	for property in properties.keys():
 		get_node(nodepath).set(property, properties[property])
-
-remote func _receive_state_array(state, value):
-	global.set(state, value)
-	global.emit_signal("debug_update")
 
 func peer_call(object, function, arguments = []):
 	for peer in map_peers:

--- a/engine/network.gd
+++ b/engine/network.gd
@@ -71,7 +71,7 @@ func initialize():
 	
 	global.emit_signal("debug_update")
 	
-remote func _sync_item_list(state, value):
+remote func _get_system_arrays(state, value):
 	states[state] = state
 	match state:
 			"weapons", "items", "pearl":
@@ -186,6 +186,14 @@ func is_map_host():
 
 func get_map_host():
 	return map_hosts.get(current_map.name)
+	
+func persistent_set_state(object, properties):
+	var nodepath = object
+	if pid == 1:
+		states[nodepath] = properties
+		global.emit_signal("debug_update")
+	else:
+		rpc_id(1, "_receive_state_change", nodepath, properties)
 
 remote func set_state(path, properties):
 	if pid == 1:

--- a/engine/network.gd
+++ b/engine/network.gd
@@ -72,6 +72,7 @@ func initialize():
 	global.emit_signal("debug_update")
 	
 remote func _get_system_arrays(state, value):
+	#This is to update Arrays for Late Session Joins. Does Nothing, needs to be worked on
 	states[state] = state
 	match state:
 			"weapons", "items", "pearl":

--- a/engine/network_object.gd
+++ b/engine/network_object.gd
@@ -47,7 +47,7 @@ func update_persistent_state():
 		return
 	for key in enter_properties.keys():
 		enter_properties[key] = get_parent().get(str(key))
-	network.set_state(get_parent().get_path(), enter_properties)
+	network.persistent_set_state(get_parent().get_path(), enter_properties)
 
 func _receive_update(properties = {}):
 	for key in properties.keys():

--- a/entities/collectables/spiritpearl.gd
+++ b/entities/collectables/spiritpearl.gd
@@ -10,8 +10,7 @@ func _ready():
 	network.peer_call(self, "set_spiritpearls", [spiritpearls])
 
 func count_pearl():
-	if network.is_map_host():
-		network.peer_call(self, "set_spiritpearls", [spiritpearls])
+	network.peer_call(self, "set_spiritpearls", [spiritpearls + 1])
 	set_spiritpearls(spiritpearls + 1)
 	emit_signal("update_persistent_state")
 	if global.spiritpearl >= max_pearls:
@@ -29,7 +28,5 @@ func on_full_slate():
 
 func set_spiritpearls(amount):
 	spiritpearls = amount
-	global.spiritpearl = amount
-	global.player.hud.update_pearls()
-	if network.is_map_host():
-		network.peer_call(global.player.hud, "update_pearls")
+	global.spiritpearl = spiritpearls
+

--- a/entities/collectables/spiritpearl.gd
+++ b/entities/collectables/spiritpearl.gd
@@ -1,27 +1,23 @@
 extends Collectable
 
 var max_pearls = 4
+var spiritpearls = 0
 var player_hud = global.player.hud
 
 signal update_persistent_state
 
-func add_pearl():
-	if network.is_map_host():
-		count_pearl()
-		if global.spiritpearl >= max_pearls:
-			global.max_health += 1
-			on_full_slate()
-			global.spiritpearl = 0
-	else:
-		network.peer_call(self, "count_pearl")
-		if global.spiritpearl >= max_pearls:
-			global.max_health += 1
-			on_full_slate()
-			global.spiritpearl = 0
+func _ready():
+	network.peer_call(self, "set_spiritpearls", [spiritpearls])
 
 func count_pearl():
-	global.spiritpearl += 1
-	network.peer_call(self, "add_pearl", [global.spiritpearl])
+	if network.is_map_host():
+		network.peer_call(self, "set_spiritpearls", [spiritpearls])
+	set_spiritpearls(spiritpearls + 1)
+	emit_signal("update_persistent_state")
+	if global.spiritpearl >= max_pearls:
+		global.max_health += 1
+		on_full_slate()
+		set_spiritpearls(0)
 	
 func on_full_slate():
 	var newheart = Sprite.new()
@@ -31,3 +27,9 @@ func on_full_slate():
 	player_hud.update_hearts()
 	player_hud.timer.start()
 
+func set_spiritpearls(amount):
+	spiritpearls = amount
+	global.spiritpearl = amount
+	global.player.hud.update_pearls()
+	if network.is_map_host():
+		network.peer_call(global.player.hud, "update_pearls")

--- a/entities/collectables/spiritpearl.tscn
+++ b/entities/collectables/spiritpearl.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://entities/collectables/spiritpearl.png" type="Texture" id=1]
 [ext_resource path="res://entities/collectables/spiritpearl.gd" type="Script" id=2]
+[ext_resource path="res://engine/network_object.tscn" type="PackedScene" id=3]
 
 [sub_resource type="CircleShape2D" id=1]
 radius = 6.36625
@@ -17,3 +18,9 @@ flip_v = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 1 )
+
+[node name="NetworkObject" parent="." instance=ExtResource( 3 )]
+persistent = true
+enter_properties = {
+"spiritpearls": 0
+}

--- a/maps/shrine.tmx
+++ b/maps/shrine.tmx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.6.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="18" nextobjectid="204">
+<map version="1.5" tiledversion="1.6.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="18" nextobjectid="209">
  <properties>
   <property name="music" value="shrine"/>
  </properties>
  <tileset firstgid="1" source="../tiled/dungeon/dungeon_tileset.tsx"/>
  <tileset firstgid="281" source="../tiled/objects.tsx"/>
- <tileset firstgid="319" source="../tiled/overworld/overworld_tileset.tsx"/>
+ <tileset firstgid="321" source="../tiled/overworld/overworld_tileset.tsx"/>
  <layer id="2" name="floor" width="40" height="40">
   <data encoding="csv">
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -138,7 +138,7 @@
 0,0,0,0,21,104,104,104,104,24,18,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,16,25,104,104,104,104,104,23,0,0,0,
 0,0,0,0,21,104,104,104,104,104,24,17,17,17,17,276,17,17,18,0,0,16,17,17,276,17,17,17,17,25,104,104,104,104,104,104,23,0,0,0,
 0,0,0,0,21,104,104,104,104,104,104,104,104,104,104,104,104,104,23,0,0,21,104,104,104,104,104,104,104,104,104,104,104,104,104,104,23,0,0,0,
-0,0,0,0,26,27,27,27,27,27,27,27,27,27,27,27,27,27,28,335,335,26,27,27,27,27,27,27,27,27,27,27,27,27,27,27,28,0,0,0
+0,0,0,0,26,27,27,27,27,27,27,27,27,27,27,27,27,27,28,337,337,26,27,27,27,27,27,27,27,27,27,27,27,27,27,27,28,0,0,0
 </data>
  </layer>
  <layer id="4" name="decor" width="40" height="40">
@@ -264,6 +264,30 @@
   <object id="171" gid="313" x="240" y="592" width="16" height="16"/>
   <object id="172" gid="313" x="224" y="592" width="16" height="16"/>
   <object id="173" gid="313" x="208" y="592" width="16" height="16"/>
+  <object id="204" gid="291" x="320" y="384" width="16" height="16">
+   <properties>
+    <property name="def" value="pearl"/>
+    <property name="item" value="Spiritpearl"/>
+   </properties>
+  </object>
+  <object id="206" gid="291" x="320" y="416" width="16" height="16">
+   <properties>
+    <property name="def" value="pearl"/>
+    <property name="item" value="Spiritpearl"/>
+   </properties>
+  </object>
+  <object id="207" gid="291" x="320" y="448" width="16" height="16">
+   <properties>
+    <property name="def" value="pearl"/>
+    <property name="item" value="Spiritpearl"/>
+   </properties>
+  </object>
+  <object id="208" gid="291" x="320" y="480" width="16" height="16">
+   <properties>
+    <property name="def" value="pearl"/>
+    <property name="item" value="Spiritpearl"/>
+   </properties>
+  </object>
  </objectgroup>
  <objectgroup id="7" name="zones" visible="0" locked="1">
   <object id="1" type="area" x="128" y="208" width="384" height="416"/>

--- a/maps/shrine.tmx
+++ b/maps/shrine.tmx
@@ -264,30 +264,6 @@
   <object id="171" gid="313" x="240" y="592" width="16" height="16"/>
   <object id="172" gid="313" x="224" y="592" width="16" height="16"/>
   <object id="173" gid="313" x="208" y="592" width="16" height="16"/>
-  <object id="204" gid="291" x="320" y="384" width="16" height="16">
-   <properties>
-    <property name="def" value="pearl"/>
-    <property name="item" value="Spiritpearl"/>
-   </properties>
-  </object>
-  <object id="206" gid="291" x="320" y="416" width="16" height="16">
-   <properties>
-    <property name="def" value="pearl"/>
-    <property name="item" value="Spiritpearl"/>
-   </properties>
-  </object>
-  <object id="207" gid="291" x="320" y="448" width="16" height="16">
-   <properties>
-    <property name="def" value="pearl"/>
-    <property name="item" value="Spiritpearl"/>
-   </properties>
-  </object>
-  <object id="208" gid="291" x="320" y="480" width="16" height="16">
-   <properties>
-    <property name="def" value="weapons"/>
-    <property name="item" value="Bomb"/>
-   </properties>
-  </object>
  </objectgroup>
  <objectgroup id="7" name="zones" visible="0" locked="1">
   <object id="1" type="area" x="128" y="208" width="384" height="416"/>

--- a/maps/shrine.tmx
+++ b/maps/shrine.tmx
@@ -284,8 +284,8 @@
   </object>
   <object id="208" gid="291" x="320" y="480" width="16" height="16">
    <properties>
-    <property name="def" value="pearl"/>
-    <property name="item" value="Spiritpearl"/>
+    <property name="def" value="weapons"/>
+    <property name="item" value="Bomb"/>
    </properties>
   </object>
  </objectgroup>

--- a/tiles/chest.gd
+++ b/tiles/chest.gd
@@ -47,7 +47,8 @@ func interact(node):
 			"dungeon":
 				network.current_map.get_node("dungeon_handler").add_key()
 			"pearl":
-				global.player.hud.count_pearl()
+				global.count_pearl()
+				network.peer_call(global, "count_pearl")
 		
 		yield(get_tree().create_timer(1), "timeout")
 		
@@ -95,3 +96,5 @@ func chest_spawn():
 			set_spawned(true)
 			hidden = false
 			emit_signal("update_persistent_state")
+			
+	

--- a/tiles/chest.gd
+++ b/tiles/chest.gd
@@ -47,7 +47,7 @@ func interact(node):
 			"dungeon":
 				network.current_map.get_node("dungeon_handler").add_key()
 			"pearl":
-				global.player.hud.collect_pearl()
+				global.player.hud.pearl()
 		
 		yield(get_tree().create_timer(1), "timeout")
 		

--- a/tiles/chest.gd
+++ b/tiles/chest.gd
@@ -47,7 +47,7 @@ func interact(node):
 			"dungeon":
 				network.current_map.get_node("dungeon_handler").add_key()
 			"pearl":
-				global.player.hud.pearl()
+				global.player.hud.count_pearl()
 		
 		yield(get_tree().create_timer(1), "timeout")
 		

--- a/tiles/chest.gd
+++ b/tiles/chest.gd
@@ -47,8 +47,7 @@ func interact(node):
 			"dungeon":
 				network.current_map.get_node("dungeon_handler").add_key()
 			"pearl":
-				global.count_pearl()
-				network.peer_call(global, "count_pearl")
+				network.add_to_state(def, item)
 		
 		yield(get_tree().create_timer(1), "timeout")
 		

--- a/ui/hud/hud.gd
+++ b/ui/hud/hud.gd
@@ -2,6 +2,8 @@ extends CanvasLayer
 
 var player
 var timer = Timer.new()
+var max_pearls = 4
+var spiritpearls = 0
 
 const ESC_PATH = "res://ui/esc_menu/esc_menu.tscn"
 const HEART_ROW_SIZE = 8
@@ -10,7 +12,7 @@ const HEART_SIZE = 8
 onready var hud2d = $hud2d
 onready var hearts = $hud2d/hearts
 onready var buttons = $hud2d/buttons
-onready var pearl = preload("res://entities/collectables/spiritpearl.tscn").instance()
+
 
 func _ready():
 	timer.connect("timeout",self,"on_slate_add") 
@@ -31,7 +33,6 @@ func initialize(p):
 	update_weapons()
 	update_tetrans()
 	update_keys()
-	update_pearls()
 
 	update_buttons()
 	Input.connect("joy_connection_changed", self, "_on_joy_connection_changed")
@@ -77,12 +78,6 @@ func update_keys():
 	if network.current_map.has_node("dungeon_handler"):
 		$keys.show()
 		$keys/keys.text = str(network.current_map.get_node("dungeon_handler").keys).pad_zeros(1)
-
-func update_pearls():
-	$tetrans/pearls.text = str(global.spiritpearl).pad_zeros(1)
-	
-func pearl():
-	pearl.count_pearl()
 
 func update_buttons():
 	var node = ""
@@ -158,6 +153,25 @@ func show_inventory():
 	add_child(inventory)
 	#inventory.start()
 	
+func count_pearl():
+	network.peer_call(self, "set_spiritpearls", [spiritpearls + 1])
+	set_spiritpearls(spiritpearls + 1)
+	if global.spiritpearl >= max_pearls:
+		global.max_health += 1
+		on_full_slate()
+		set_spiritpearls(0)
+		
+func set_spiritpearls(amount):
+	spiritpearls = amount
+	global.spiritpearl = spiritpearls
+	
+func on_full_slate():
+	var newheart = Sprite.new()
+	newheart.texture = hearts.texture
+	newheart.hframes = hearts.hframes
+	hearts.add_child(newheart)
+	update_hearts()
+	timer.start()
 	
 func on_slate_add():
 	if global.player.health < global.max_health:

--- a/ui/hud/hud.gd
+++ b/ui/hud/hud.gd
@@ -31,6 +31,7 @@ func initialize(p):
 	update_weapons()
 	update_tetrans()
 	update_keys()
+	update_pearls()
 
 	update_buttons()
 	Input.connect("joy_connection_changed", self, "_on_joy_connection_changed")
@@ -76,6 +77,12 @@ func update_keys():
 	if network.current_map.has_node("dungeon_handler"):
 		$keys.show()
 		$keys/keys.text = str(network.current_map.get_node("dungeon_handler").keys).pad_zeros(1)
+
+func update_pearls():
+	$tetrans/pearls.text = str(global.spiritpearl).pad_zeros(1)
+	
+func pearl():
+	pearl.count_pearl()
 
 func update_buttons():
 	var node = ""
@@ -151,8 +158,6 @@ func show_inventory():
 	add_child(inventory)
 	#inventory.start()
 	
-func collect_pearl():
-	pearl.add_pearl()
 	
 func on_slate_add():
 	if global.player.health < global.max_health:

--- a/ui/hud/hud.gd
+++ b/ui/hud/hud.gd
@@ -162,6 +162,7 @@ func count_pearl():
 		set_spiritpearls(0)
 		
 func set_spiritpearls(amount):
+	print(amount)
 	spiritpearls = amount
 	global.spiritpearl = spiritpearls
 	

--- a/ui/hud/hud.gd
+++ b/ui/hud/hud.gd
@@ -39,7 +39,6 @@ func initialize(p):
 
 	$hud2d/Z.modulate = Color(1,1,1,0.3)
 
-
 func update_hearts():
 	for heart in hearts.get_children():
 		var index = heart.get_index()
@@ -152,20 +151,7 @@ func show_inventory():
 	var inventory = preload("res://ui/inventory/inventory.tscn").instance()
 	add_child(inventory)
 	#inventory.start()
-	
-func count_pearl():
-	network.peer_call(self, "set_spiritpearls", [spiritpearls + 1])
-	set_spiritpearls(spiritpearls + 1)
-	if global.spiritpearl >= max_pearls:
-		global.max_health += 1
-		on_full_slate()
-		set_spiritpearls(0)
-		
-func set_spiritpearls(amount):
-	print(amount)
-	spiritpearls = amount
-	global.spiritpearl = spiritpearls
-	
+
 func on_full_slate():
 	var newheart = Sprite.new()
 	newheart.texture = hearts.texture

--- a/ui/hud/hud.tscn
+++ b/ui/hud/hud.tscn
@@ -175,20 +175,6 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="pearls" type="Label" parent="tetrans"]
-margin_left = 29.888
-margin_top = 5.0
-margin_right = 47.888
-margin_bottom = 18.0
-size_flags_horizontal = 0
-size_flags_vertical = 0
-theme = ExtResource( 6 )
-custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
-text = "0"
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
 [node name="keys" type="Node2D" parent="."]
 position = Vector2( 8, 30 )
 

--- a/ui/hud/hud.tscn
+++ b/ui/hud/hud.tscn
@@ -200,6 +200,7 @@ __meta__ = {
 }
 
 [node name="debug" type="Control" parent="."]
+visible = false
 margin_right = 40.0
 margin_bottom = 40.0
 theme = ExtResource( 6 )

--- a/ui/hud/hud.tscn
+++ b/ui/hud/hud.tscn
@@ -175,6 +175,20 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="pearls" type="Label" parent="tetrans"]
+margin_left = 29.888
+margin_top = 5.0
+margin_right = 47.888
+margin_bottom = 18.0
+size_flags_horizontal = 0
+size_flags_vertical = 0
+theme = ExtResource( 6 )
+custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
+text = "0"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [node name="keys" type="Node2D" parent="."]
 position = Vector2( 8, 30 )
 

--- a/ui/hud/hud.tscn
+++ b/ui/hud/hud.tscn
@@ -200,7 +200,6 @@ __meta__ = {
 }
 
 [node name="debug" type="Control" parent="."]
-visible = false
 margin_right = 40.0
 margin_bottom = 40.0
 theme = ExtResource( 6 )

--- a/ui/inventory/inventory.gd
+++ b/ui/inventory/inventory.gd
@@ -8,11 +8,11 @@ var selected = 0
 
 func _ready():
 	get_parent().update_weapons()
-	update_pearls()
 	anim.play("slideup")
 	sfx.play("inventory_open")
 
 func start():
+	update_pearls()
 	add_weapons()
 	yield(get_tree(), "physics_frame")
 	change_selection(0)

--- a/ui/inventory/inventory.gd
+++ b/ui/inventory/inventory.gd
@@ -77,8 +77,6 @@ func set_weapon(btn):
 	get_parent().update_weapons()
 	
 func update_pearls():
-	print("network: ", int(network.states["pearl"].size()))
-	print("global: ", int(global.pearl.size()))
 	var pearl_icon = $spiritpearl/pearl_icon
 	pearl_icon.frame = pearl_icon.frame + global.pearl.size()
 	$spiritpearl/pearl_qty.text = str("x",global.pearl.size())

--- a/ui/inventory/inventory.gd
+++ b/ui/inventory/inventory.gd
@@ -77,6 +77,8 @@ func set_weapon(btn):
 	get_parent().update_weapons()
 	
 func update_pearls():
+	print("network: ", int(network.states["pearl"].size()))
+	print("global: ", int(global.pearl.size()))
 	var pearl_icon = $spiritpearl/pearl_icon
-	pearl_icon.frame = pearl_icon.frame + global.spiritpearl
-	$spiritpearl/pearl_qty.text = str("x",global.spiritpearl)
+	pearl_icon.frame = pearl_icon.frame + global.pearl.size()
+	$spiritpearl/pearl_qty.text = str("x",global.pearl.size())


### PR DESCRIPTION
### Summary
When attempting to Sync Collectables, we unknowingly caused issues among Sharing Items, and Persistent State. My Goal was to network the Spirit Pearls, but in so doing I found the flaws in the code. This PR Remedies all of these as well as my original goal of Properly adding Spirit Pearls. Some more code clean up may be required, but overall things are set and working.

### Testing
Open a Chest anywhere, or add to the Shrine during a multiplayer Session. Regardless whether the players are on the same map or not, the items will update for everyone, and the chest will be open for everyone, and remain open. 

[**Has this been tested in multiplayer?**](https://github.com/loudsmilestudios/TetraForce/wiki/How-to-test-multiplayer) 
The whole point of this PR, so you bet your boots :) 
