### PR TITLE
BUGFIX: Reset `network.pid` on exit

### DIFF
--- a/engine/network.gd
+++ b/engine/network.gd
@@ -51,6 +51,7 @@ func complete():
 	current_map.queue_free()
 	get_tree().set_network_peer(null)
 	clean_session_data()
+	pid = 1
 
 func initialize():
 	tick = Timer.new()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21203171/127409015-276c519a-b8f3-40b1-a71c-d94645e5d9a8.png)
In multiplayer game
![image](https://user-images.githubusercontent.com/21203171/127409036-099d627f-bd9d-4078-b9b6-20e2261923ff.png)
In singleplayer game without restart

### Summary
`network.pid` needed to be set to `1`, its default value, when exiting a game. Otherwise that value is malformed causing issues when hosting a game.

### Testing
1. Join multiplayer game (not as host)
2. Exit game to main menu
3. Start singleplayer game

[**Has this been tested in multiplayer?**](https://github.com/loudsmilestudios/TetraForce/wiki/How-to-test-multiplayer) yes
