### PR TITLE
Push Docker Image To ECR & Clear Build Cache

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -66,7 +66,6 @@ jobs:
           IMAGE_URI: "141264065387.dkr.ecr.us-east-2.amazonaws.com/tetraforce"
           BUILD_PATH: "."
           DOCKERFILE: "Dockerfile"
-          IMAGE_NAME: "tetraforce"
           TAG_NAME: ${{ steps.get_tag.outputs.TAG }}
           LATEST: "true"
   linux:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -104,6 +104,15 @@ jobs:
           AWS_REGION: us-east-2
           SOURCE_DIR: ${{github.workspace}}/tetraforce
           DEST_DIR: builds/master/latest/linux
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Clear CloudFront Cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_ID }} --paths "/builds/master/latest/linux/*"
   windows:
     name: Build & Push - Windows
     runs-on: ubuntu-latest
@@ -142,6 +151,15 @@ jobs:
           AWS_REGION: us-east-2
           SOURCE_DIR: ${{github.workspace}}/tetraforce
           DEST_DIR: builds/master/latest/${{ matrix.platform }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Clear CloudFront Cache
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_ID }} --paths "/builds/master/latest/${{ matrix.platform }}/*"
   osx:
     name: Build OSX
     runs-on: macos-latest
@@ -193,6 +211,15 @@ jobs:
         AWS_REGION: us-east-2
         SOURCE_DIR: ${{github.workspace}}/tetraforce
         DEST_DIR: builds/master/latest/osx
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-2
+    - name: Clear CloudFront Cache
+      run: |
+        aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_ID }} --paths "/builds/master/latest/osx/*"
   html5:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -55,6 +55,20 @@ jobs:
           IMAGE_NAME: "tetraforce"
           TAG_NAME: ${{ steps.get_tag.outputs.TAG }}
           LATEST: "true"
+      - name: Docker Build & Push to AWS ECR
+        uses: opspresso/action-docker@master
+        with:
+          args: --ecr
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: "us-east-2"
+          IMAGE_URI: "141264065387.dkr.ecr.us-east-2.amazonaws.com/tetraforce"
+          BUILD_PATH: "."
+          DOCKERFILE: "Dockerfile"
+          IMAGE_NAME: "tetraforce"
+          TAG_NAME: ${{ steps.get_tag.outputs.TAG }}
+          LATEST: "true"
   linux:
     name: Build & Push - Linux
     runs-on: ubuntu-latest


### PR DESCRIPTION

### Summary
This PR updates the build system to better support deployments.

On publish:
- Docker images will now be deployed to ECR & be the default version to run when a new server is requested
- After a new build is released, it will clear the cached version

### Testing
Only way to test is to run a new release
