### PR TITLE
fixed block syncing on player entry, removed tall grass persistency, …

### DIFF
--- a/maps/shrine.tmx
+++ b/maps/shrine.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.5" tiledversion="1.6.0" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="18" nextobjectid="209">
+<map version="1.4" tiledversion="1.4.3" orientation="orthogonal" renderorder="right-down" width="40" height="40" tilewidth="16" tileheight="16" infinite="0" nextlayerid="18" nextobjectid="211">
  <properties>
   <property name="music" value="shrine"/>
  </properties>
@@ -264,6 +264,8 @@
   <object id="171" gid="313" x="240" y="592" width="16" height="16"/>
   <object id="172" gid="313" x="224" y="592" width="16" height="16"/>
   <object id="173" gid="313" x="208" y="592" width="16" height="16"/>
+  <object id="209" gid="283" x="288" y="528" width="16" height="16"/>
+  <object id="210" gid="283" x="336" y="528" width="16" height="16"/>
  </objectgroup>
  <objectgroup id="7" name="zones" visible="0" locked="1">
   <object id="1" type="area" x="128" y="208" width="384" height="416"/>

--- a/tiles/block.gd
+++ b/tiles/block.gd
@@ -3,10 +3,8 @@ extends StaticBody2D
 onready var ray = $RayCast2D
 onready var tween = $Tween
 
-onready var target_position = position setget set_position
+onready var target_position = position setget set_block_position
 onready var pushed = false setget set_pushed
-
-signal update_persistent_state
 
 func _ready():
 	add_to_group("pushable")
@@ -28,11 +26,11 @@ func attempt_move(direction):
 		move_to(position, target_position)
 		network.peer_call(self, "move_to", [position, target_position])
 		network.peer_call(self, "set_pushed", [pushed])
-		network.set_state(self, {"target_position":target_position, "pushed":pushed})
 
-func set_position(value):
-	position = value
-	
+func set_block_position(value):
+	target_position = value
+	snap_to(position, target_position)
+
 func set_pushed(value):
 	pushed = value
 
@@ -40,5 +38,7 @@ func move_to(current_pos, target_pos):
 	tween.interpolate_property(self, "position", current_pos, target_pos, 1.0, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
 	tween.start()
 	sfx.play("push")
-	
 
+func snap_to(current_pos, target_pos):
+	tween.interpolate_property(self, "position", current_pos, target_pos, 0.1, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
+	tween.start()

--- a/tiles/block.tscn
+++ b/tiles/block.tscn
@@ -32,7 +32,6 @@ collision_mask = 3
 [node name="Tween" type="Tween" parent="."]
 
 [node name="NetworkObject" parent="." instance=ExtResource( 3 )]
-persistent = true
 enter_properties = {
 "pushed": false,
 "target_position": Vector2( 0, 0 )

--- a/tiles/tall_grass.gd
+++ b/tiles/tall_grass.gd
@@ -3,19 +3,16 @@ extends TileMap
 var cut_cells = [] setget enter_cut_cells
 var walkfx_texture = preload("res://effects/walkfx_grass.png")
 
-signal update_persistent_state
-
 func _ready():
 	var network_object = preload("res://engine/network_object.tscn").instance()
 	network_object.enter_properties = {"cut_cells":[]}
-	network_object.persistent = true
+	network_object.persistent = false
 	add_child(network_object)
 	add_to_group("fxtile")
 
 func cut(hitbox):
 	var tile = world_to_map(hitbox.global_position)
 	process_tile(tile)
-	emit_signal("update_persistent_state")
 	network.peer_call(self, "process_tile", [tile])
 
 func enter_cut_cells(value):


### PR DESCRIPTION
…some import files


<!-- PLEASE PROVIDE A SCREENSHOT IF POSSIBLE -->

### Summary
Blocks now correctly sync on player entry. Removed persistency from tall grass so they respawn when all players leave. Pushed some import files.

### Testing
push block with one player and leave and come back

[**Has this been tested in multiplayer?**](https://github.com/loudsmilestudios/TetraForce/wiki/How-to-test-multiplayer) yes
