### PR TITLE
PvP Toggle added to options & Volume Bugfix

### DIFF
--- a/ui/options/gameplay.tscn
+++ b/ui/options/gameplay.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=9 format=2]
 
+[ext_resource path="res://ui/options/pvp_toggle.gd" type="Script" id=1]
 [ext_resource path="res://entities/player/chain.png" type="Texture" id=2]
 [ext_resource path="res://ui/main/characterselect.gd" type="Script" id=3]
 [ext_resource path="res://ui/theme/font.ttf" type="DynamicFontData" id=4]
+[ext_resource path="res://ui/theme/theme.tres" type="Theme" id=5]
 
 [sub_resource type="Animation" id=1]
 loop = true
@@ -108,5 +110,18 @@ autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="pvp_toggle" type="Button" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -39.0
+margin_top = 45.5
+margin_right = 42.4557
+margin_bottom = 67.5
+theme = ExtResource( 5 )
+text = "PvP Enabled"
+script = ExtResource( 1 )
 
 [connection signal="text_changed" from="characterselect/name" to="characterselect" method="_on_name_text_changed"]

--- a/ui/options/options.tscn
+++ b/ui/options/options.tscn
@@ -63,17 +63,3 @@ text = "Disable Text Filter"
 __meta__ = {
 "_edit_use_anchors_": false
 }
-
-[node name="PvPButton" type="Button" parent="Misc"]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -57.7414
-margin_top = 0.558739
-margin_right = 64.7143
-margin_bottom = 24.5587
-text = "Disable PvP"
-__meta__ = {
-"_edit_use_anchors_": false
-}

--- a/ui/options/pvp_toggle.gd
+++ b/ui/options/pvp_toggle.gd
@@ -6,7 +6,7 @@ func _ready():
 
 func toggle_pvp():
 	if not "pvp" in global.options:
-		global.options["pvp"] = true
+		global.options["pvp"] = false
 	else:
 		global.options["pvp"] = !global.options["pvp"]
 	update_options()

--- a/ui/options/pvp_toggle.gd
+++ b/ui/options/pvp_toggle.gd
@@ -14,5 +14,7 @@ func toggle_pvp():
 func update_options():
 	if not "pvp" in global.options or global.options["pvp"]:
 		self.text = "PvP: Enabled"
+		global.pvp = true
 	else:
 		self.text = "PvP: Disabled"
+		global.pvp = false

--- a/ui/options/pvp_toggle.gd
+++ b/ui/options/pvp_toggle.gd
@@ -1,0 +1,18 @@
+extends Button
+
+func _ready():
+	global.connect("options_loaded", self, "update_options")
+	self.connect("button_down", self, "toggle_pvp")
+
+func toggle_pvp():
+	if not "pvp" in global.options:
+		global.options["pvp"] = true
+	else:
+		global.options["pvp"] = !global.options["pvp"]
+	update_options()
+
+func update_options():
+	if not "pvp" in global.options or global.options["pvp"]:
+		self.text = "PvP: Enabled"
+	else:
+		self.text = "PvP: Disabled"

--- a/ui/options/sound.gd
+++ b/ui/options/sound.gd
@@ -5,9 +5,9 @@ onready var master_slider : Slider = $VBoxContainer/Master/Slider
 func _ready():
 	global.connect("options_loaded", self, "update_options")
 	
-	master_slider.value = db_to_percent(0)
+	master_slider.value = 50
+	on_master_slider_change(master_slider.value)
 	master_slider.connect("value_changed", self, "on_master_slider_change")
-	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), 0)
 
 func update_options():
 	if not "sound" in global.options:

--- a/ui/options/sound.gd
+++ b/ui/options/sound.gd
@@ -17,10 +17,10 @@ func update_options():
 		on_master_slider_change(master_slider.value)
 
 func db_to_percent(db : float) -> float:
-	return ((db + 6) / 86) * 100
+	return db2linear(db)
 
 func percent_to_db(pct : float) -> float:
-	return pct / 100 * 86 - 6
+	return linear2db(pct / 100)
 
 func on_master_slider_change(new_value):
 	if not "sound" in global.options:

--- a/ui/options/sound.tscn
+++ b/ui/options/sound.tscn
@@ -45,7 +45,6 @@ margin_left = 48.0
 margin_right = 232.0
 margin_bottom = 10.0
 grow_horizontal = 2
-max_value = 50.0
 __meta__ = {
 "_edit_use_anchors_": false
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21203171/133348787-24a8f65a-9cca-4c54-8839-8f73f8f9ecfa.png)

### Summary
- PvP Toggle is now settable in options
- Volume slider can now go to zero!

### Testing
1. You can test PvP changes by changing PvP toggle before joining a multiplayer game and seeing results
2. Volume changes can be easily done by trying to drag volume to zero

[**Has this been tested in multiplayer?**](https://github.com/loudsmilestudios/TetraForce/wiki/How-to-test-multiplayer) *kinda?* Tested with same configuration file, not cross system
