### PR TITLE
Update `network_object.gd` to set states as strings

### DIFF
--- a/engine/network_object.gd
+++ b/engine/network_object.gd
@@ -51,7 +51,7 @@ func update_persistent_state():
 		return
 	for key in enter_properties.keys():
 		enter_properties[key] = get_parent().get(str(key))
-	network.persistent_set_state(get_parent().get_path(), enter_properties)
+	network.persistent_set_state(str(get_parent().get_path()), enter_properties)
 
 func receive_update(properties = {}):
 	for key in properties.keys():

--- a/maps/dungeon1.tmx
+++ b/maps/dungeon1.tmx
@@ -2035,7 +2035,7 @@
   <object id="14" gid="373" x="896" y="496" width="16" height="16"/>
   <object id="15" gid="373" x="896" y="480" width="16" height="16"/>
   <object id="16" gid="373" x="896" y="464" width="16" height="16"/>
-  <object id="41" name="ship_entrance" gid="372" x="464" y="528" width="16" height="16">
+  <object id="41" name="ship_entrance" gid="372" x="624" y="1152" width="16" height="16">
    <properties>
     <property name="entrance" value="ship_entrance"/>
     <property name="map" value="shoreside"/>

--- a/maps/shrine.tmx
+++ b/maps/shrine.tmx
@@ -264,7 +264,6 @@
   <object id="171" gid="313" x="240" y="592" width="16" height="16"/>
   <object id="172" gid="313" x="224" y="592" width="16" height="16"/>
   <object id="173" gid="313" x="208" y="592" width="16" height="16"/>
-  <object id="243" gid="283" x="336" y="464" width="16" height="16"/>
  </objectgroup>
  <objectgroup id="7" name="zones" visible="0">
   <object id="1" name="1" type="area" x="128" y="368" width="384" height="256"/>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21203171/135738246-0fbf5bf2-10f3-4cde-a27e-f7aa4eb8f759.png)

This is a bugfix that allows enter properties to work for persistent values within the string based saving system.